### PR TITLE
Update treesitter.lua

### DIFF
--- a/nvim/lua/user/plugins/treesitter.lua
+++ b/nvim/lua/user/plugins/treesitter.lua
@@ -65,9 +65,6 @@ return {
       enable = true,
       disable = { "yaml" }
     },
-    context_commentstring = {
-      enable = true,
-    },
     rainbow = {
       enable = true,
     },


### PR DESCRIPTION
When I start nvim and then load the first file in NeoVim (through using <leader>f ) this warning message is displayed, followed by the stack trace:

"context_commentstring nvim-treesitter module is deprecated, use require('ts_context_commentstring').setup {} and set vim.g.skip_ts_context_commentstring_module = true to speed up loading instead.                                                                                                                                                                          This feature will be removed in ts_context_commentstring version in the future (see https://github.com/JoosepAlviste/nvim-ts-context-commentstring/issues/82 for more info)"

After following the instructions found in the link https://github.com/JoosepAlviste/nvim-ts-context-commentstring/issues/82 ie: remove the:

  context_commentstring = {
    enable = true,
  },

(in treesitter.lua)

and then Lazy -> Update

the warning does not show any more.