### PR TITLE
Safely wrap strings with quotes

### DIFF
--- a/scripts/t
+++ b/scripts/t
@@ -14,11 +14,11 @@ if [[ $selected == '' ]]; then
     exit
 fi
 
-dirname=`basename $selected | sed 's/\./_/g'`
+dirname=`basename "$selected" | sed 's/\./_/g'`
 
-tmux switch-client -t =$dirname
+tmux switch-client -t ="$dirname"
 if [[ $? -eq 0 ]]; then
     exit 0
 fi
 
-tmux new-session -c $selected -d -s $dirname && tmux switch-client -t $dirname || tmux new -c $selected -A -s $dirname
+tmux new-session -c "$selected" -d -s "$dirname" && tmux switch-client -t "$dirname" || tmux new -c "$selected" -A -s "$dirname"


### PR DESCRIPTION
If there is a folder with space characters the script would break. By adding quotes, we may solve it